### PR TITLE
feat: add release to preprod for updates

### DIFF
--- a/.jx/updatebot.yaml
+++ b/.jx/updatebot.yaml
@@ -1,0 +1,12 @@
+apiVersion: updatebot.jenkins-x.io/v1alpha1
+kind: UpdateConfig
+spec:
+  rules:
+    - urls:
+        - https://github.com/spring-financial-group/JX3_Azure_Vault_Dev_Cluster
+      changes:
+        - regex:
+            pattern: '- chart: dev\/mongodb-bi\n  version: (.*?)\n'
+            files:
+              - "**/jx-preproduction/helmfile.yaml"
+      reusePullRequest: false

--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -53,7 +53,7 @@ spec:
         - name: promote-helm-release
           resources: {}
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/updatebot/release.yaml@versionStream
-          resources: { }
+          resources: {}
   podTemplate: {}
   serviceAccountName: tekton-bot
   timeout: 12h0m0s

--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -52,6 +52,8 @@ spec:
             jx changelog create --version v${VERSION}
         - name: promote-helm-release
           resources: {}
+        - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/updatebot/release.yaml@versionStream
+          resources: { }
   podTemplate: {}
   serviceAccountName: tekton-bot
   timeout: 12h0m0s


### PR DESCRIPTION
- unsure how much this gets used on preprod (could consider to remove). However, failing to pull image for the service running in preprod as image can not be pulled from acr. 
- Adding auto release functionality so changes will be pushed to preprod to mitigate future issues