### PR TITLE
fix: update libs1.1 pkg as br0ken

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ WORKDIR /home/mongobi
 # Setting noninteractive mode to quiet debconf warnings
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 RUN apt-get update \
-    && apt-get install -y nano curl wget
+    && apt-get install -y nano curl wget \
+    && apt-get install -y openssl \
+    && wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb\
+    && dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
 RUN wget -nv https://info-mongodb-com.s3.amazonaws.com/mongodb-bi/v2/mongodb-bi-linux-x86_64-debian92-v2.14.0.tgz && \
     tar -xvzf mongodb-bi-linux-x86_64-debian92-v2.14.0.tgz
 WORKDIR /home/mongobi/mongodb-bi-linux-x86_64-debian92-v2.14.0


### PR DESCRIPTION
Saw that MongoDB BI is having some issues and thought I would give it some help as I don't like seeing upset containers on our clusters :(

#### Error: 
mongosqld: error while loading shared libraries: libssl.so.1.1: cannot open shared object file: No such file or directory

#### Fix: 
Update libs1.1 pkg supported in the image that MongoDB BI service requires